### PR TITLE
Add function to ignore certain events + easter egg

### DIFF
--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -36,7 +36,7 @@ var socket = io(document.location.hostname);
 socket.on('github', function (data) {
   $('.online-users-count').html(data.connected_users);
   data.data.forEach(function(event){
-    if(!isEventInQueue(event)){
+    if(!isEventInQueue(event) || shouldEventBeIgnored(event)){
       eventQueue.push(event);
     }
   });
@@ -86,6 +86,16 @@ function isEventInQueue(event){
   }
   return false;
 }
+
+/**
+ * This function adds a filter for events that we don't want to hear.
+ *
+ * To extend this function, simply add return true for events that should be filtered.
+ */
+function shouldEventBeIgnored(event){
+  return false;
+}
+  
 
 $(function(){
   element = document.documentElement;

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -93,6 +93,10 @@ function isEventInQueue(event){
  * To extend this function, simply add return true for events that should be filtered.
  */
 function shouldEventBeIgnored(event){
+  // This adds an easter egg to only play closed PRs
+  if (!!ULTIMATE_DREAM_KILLER)
+    return (event.type !== "PullRequestEvent" || event.action !== "closed");
+
   return false;
 }
   


### PR DESCRIPTION
I just have too much free time ¯\\\_\(ツ\)_/¯

Feel free to ignore the easter egg but I think the filter function could be useful in a future if you want to add filters. I love the simplicity of the website though so it's fine if you don't want to add this.

Love the project! :heart:

----
##### Add function to ignore events:

This commit adds a filter function for events that should be ignored, which can be extended later via a commit or a DevTools hack.

##### Add easter egg to only play closed PRs:

To use this, just set `ULTIMATE_DREAM_KILLER` in your DevTools console. 

The explanation for this easter egg can be found [in this article](https://blog.jessfraz.com/post/the-art-of-closing/). Just look for `Ultimate Dream Killers`. Some people just like to see other people's dreams crushed :-1:
