### PR TITLE
Allow custom events URL via GITHUB_EVENTS_URL.

### DIFF
--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -32,7 +32,8 @@ var svg_background_color_online = '#0288D1',
 
 
 
-var socket = io(document.location.hostname);
+var socketHost = document.location.hostname + ":" + document.location.port;
+var socket = io(socketHost);
 socket.on('github', function (data) {
   $('.online-users-count').html(data.connected_users);
   data.data.forEach(function(event){

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,8 @@ const logger = require('./logger');
 const argv = require('minimist')(process.argv.slice(2));
 const isDev = process.env.NODE_ENV !== 'production';
 
+var githubEventsUrl = process.env.GITHUB_EVENTS_URL || 'https://api.github.com/events';
+
 // Get the intended port number, use port 8000 if not provided
 const port = argv.port || process.env.PORT || 8000;
 server.listen(port, (err) => {
@@ -67,7 +69,7 @@ io.on('connection', function (socket) {
 // Function to get events from GitHub API
 function fetchDataFromGithub(){
   var options = {
-    url: 'https://api.github.com/events',
+    url: githubEventsUrl,
     headers: {
       'User-Agent': 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36',
       'Authorization': 'token ' + process.env.GITHUB_OAUTH_KEY


### PR DESCRIPTION
Allow fetching custom events, by setting the `GITHUB_EVENTS_URL` environment variable.
The value of `GITHUB_EVENTS_URL` can be anyone of the URLs listed [here](https://developer.github.com/v3/activity/events/).

Also added port to socket.io initialization to fix local development.