### PR TITLE
Mixed improvements on server and client

### DIFF
--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -338,7 +338,7 @@ function drawEvent(data, svg_area) {
         .remove();
 
     var circle_container = circle_group.append('a');
-    circle_container.attr('xlink:href', 'https://github.com/' + data.repo_name);
+    circle_container.attr('xlink:href', data.url);
     circle_container.attr('target', '_blank');
     circle_container.attr('fill', svg_text_color);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/debugger22/github-audio#readme",
   "dependencies": {
     "chalk": "^1.1.3",
+    "cross-env": "^3.1.2",
     "express": "^4.14.0",
     "helmet": "^2.2.0",
     "ip": "^1.1.3",

--- a/server/index.js
+++ b/server/index.js
@@ -116,7 +116,8 @@ function stripData(data){
           'repo_name': data.repo.name,
           'payload_size': data.payload.size,
           'message': data.payload.commits[0].message,
-          'created': data.created_at
+          'created': data.created_at,
+          'url': data.repo.url
         });
         pushEventCounter++;
       }
@@ -130,7 +131,8 @@ function stripData(data){
         'repo_name': data.repo.name,
         'payload_size': 0,
         'message': data.body,
-        'created': data.created_at
+        'created': data.created_at,
+        'url': data.payload.comment.html_url
       });
     }else if(data.type == 'PullRequestEvent'){
       if (data.payload.pull_request.merged) data.payload.action = 'merged';
@@ -143,7 +145,8 @@ function stripData(data){
         'repo_name': data.repo.name,
         'action': data.payload.action,  // opened, reopened, closed, merged
         'message': data.payload.pull_request.title,
-        'created': data.created_at
+        'created': data.created_at,
+        'url': data.payload.pull_request.html_url
       });
     }else if(data.type == 'IssuesEvent'){
       stripedData.push({
@@ -155,7 +158,8 @@ function stripData(data){
         'repo_name': data.repo.name,
         'action': data.payload.action,  // opened, reopened, closed
         'message': data.payload.issue.title,
-        'created': data.created_at
+        'created': data.created_at,
+        'url': data.payload.issue.html_url
       });
     }
   });

--- a/server/index.js
+++ b/server/index.js
@@ -133,6 +133,7 @@ function stripData(data){
         'created': data.created_at
       });
     }else if(data.type == 'PullRequestEvent'){
+      if (data.payload.pull_request.merged) data.payload.action = 'merged';
       stripedData.push({
         'id': data.id,
         'type': data.type,


### PR DESCRIPTION
This PR contains the following improvements:

- Add `cross-env` dependency so that `npm start` works.

- Mark PullRequestEvents as `merged` when appropriate: as is now, closed and merged PRs have both an `action = closed`. See the description of the action field in the [PullRequestEvent documentation](https://developer.github.com/v3/activity/events/types/#pullrequestevent).

- Include URL of the specific event when sending it to the client, and display that in the client. This includes all events except PushEvents which don't include an appropriate URL in the API response.

Tested locally.